### PR TITLE
Features to consider

### DIFF
--- a/.github/workflows/docker-crossbuild.yml
+++ b/.github/workflows/docker-crossbuild.yml
@@ -1,0 +1,37 @@
+name: Build Container Images for Mailrise
+
+on:
+  push:
+    branches:
+      - master
+      - main
+
+jobs:
+  apacheds:
+    name: Build Mailrise
+
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: crazy-max/ghaction-docker-buildx@v3
+        with:
+          buildx-version: latest
+          qemu-version: latest
+
+      - name: Docker Login
+        env:
+          DOCKER_USERNAME: ${{ secrets.GHCR_USER }}
+          DOCKER_PASSWORD: ${{ secrets.GHCR_TOKEN }}
+        run: |-
+          docker login ghcr.io -u "${DOCKER_USERNAME}" -p "${DOCKER_PASSWORD}"
+
+      - name: Run Crossbuild
+        run: |-
+          docker buildx build \
+            --platform linux/amd64,linux/arm/v7,linux/arm64 \
+            -t "ghcr.io/homelab-library/mailrise:latest" \
+            -t "ghcr.io/homelab-library/mailrise:$(date '+%Y%m%d%H%M')" --push .

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,13 @@ RUN apk add build-base git libffi-dev rust cargo openssl-dev
 
 # Build and install to /dist
 COPY ["setup.cfg", "setup.py", "./"]
+RUN pip install --use-feature=in-tree-build --root /dist --no-warn-script-location -e . || true
 COPY src/ src/
-RUN pip install --no-cache-dir --use-feature=in-tree-build --root /dist --no-warn-script-location .
+RUN pip install --use-feature=in-tree-build --root /dist --no-warn-script-location .
 
 # Published container
 FROM python:3.9-alpine as target
 RUN apk add --no-cache libffi openssl
 COPY --from=builder /dist/ /
 EXPOSE 8025
-CMD [ "mailrise", "/etc/mailrise.conf" ]
+CMD [ "mailrise", "/etc/mailrise.conf", "-v" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
-FROM python:3
+# This image is only used for build so we don't care about size
+FROM python:3.9-alpine as builder
+WORKDIR /build
 
-WORKDIR /usr/src/mailrise
+# Add packages needed to build wheels
+RUN apk update && mkdir -p /dist
+RUN apk add build-base git libffi-dev rust cargo openssl-dev
 
-COPY . .
-RUN pip install --no-cache-dir --use-feature=in-tree-build .
+# Build and install to /dist
+COPY ["setup.cfg", "setup.py", "./"]
+COPY src/ src/
+RUN pip install --no-cache-dir --use-feature=in-tree-build --root /dist --no-warn-script-location .
 
+# Published container
+FROM python:3.9-alpine as target
+RUN apk add --no-cache libffi openssl
+COPY --from=builder /dist/ /
 EXPOSE 8025
 CMD [ "mailrise", "/etc/mailrise.conf" ]

--- a/buildx.sh
+++ b/buildx.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+export DOCKER_CLI_EXPERIMENTAL=enabled
+
+docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+
+docker buildx build \
+    --platform linux/amd64,linux/arm/v7,linux/arm64 \
+    -t "ghcr.io/homelab-library/mailrise:latest" .

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+docker build .
+exec docker run --rm --net host -it \
+    -v $PWD/mailrise.conf~:/etc/mailrise.conf:ro \
+    $(docker build -q .)

--- a/src/mailrise/skeleton.py
+++ b/src/mailrise/skeleton.py
@@ -86,7 +86,7 @@ def setup_logging(loglevel: int) -> None:
     Args:
       loglevel (int): Minimum loglevel for emitting messages.
     """
-    logformat = "[%(asctime)s] %(levelname)s:%(name)s:%(message)s"
+    logformat = "[%(asctime)s] %(levelname)s:%(name)s: %(message)s"
     logging.basicConfig(
         level=loglevel, stream=sys.stdout, format=logformat, datefmt="%Y-%m-%d %H:%M:%S"
     )
@@ -102,6 +102,7 @@ def main(args: list[str]) -> None:
     """
     pargs = parse_args(args)
     setup_logging(pargs.loglevel)
+    _logger.info("Starting mailrise...")
 
     try:
         config = load_config(_logger, pargs.config)

--- a/src/mailrise/smtp.py
+++ b/src/mailrise/smtp.py
@@ -67,9 +67,13 @@ def parsercpt(addr: str) -> Recipient:
         The `Recipient` instance.
     """
     _, email = parseaddr(addr)
+    email_parts = email.split("@", 1)
+    email_user = email_parts[0]
+    email_domain = email_parts[1]
+
     rx_types = r'((?:\.(?:info|success|warning|failure))?)'
-    rx = f'(?:"([^"@\\.]*){rx_types}"|([^@\\.]*){rx_types})@mailrise\\.xyz$'
-    match = re.search(rx, email, re.IGNORECASE)
+    rx = f'(?:"([^"@\\.]*){rx_types}"|([^@\\.]*){rx_types})$'
+    match = re.search(rx, email_user, re.IGNORECASE)
     if match is None:
         raise RecipientError(f"'{email}' is not a valid mailrise recipient")
     quoted = match.group(1) is not None
@@ -86,7 +90,7 @@ def parsercpt(addr: str) -> Recipient:
     elif ntypes == '.failure':
         ntype = apprise.NotifyType.FAILURE
 
-    return Recipient(config_key=key, notify_type=ntype)
+    return Recipient(config_key=f"{key}@{email_domain}", notify_type=ntype)
 
 
 @dataclass


### PR DESCRIPTION
First off, this can't be merged as is because the CI script will fail (it's pointing to this fork's package repo) -- but I still wanted to get this here for you to consider. Here are the changes in this fork:

- Docker image size reduced from 919MB to 58.9MB for amd64
- Made dockerfile compatible with arm64, arm32
- Github Actions to automatically build & publish a multiplatform image for amd64/arm64/arm32
- Removed the hardcoded `mailrise.xyz` domain from destination addresses
    - If the config key appears to have a domain, e.g. `phil@example.com`, it will just use that address
    - If the config key does not have a domain, e.g. `phil`, then the default domain is appended resulting in something like `phil@mailrise.xyz`
    - Added a config entry for `default_domain` that is set to `mailrise.xyz` when omitted to be consistent with the previous behavior