### PR TITLE
Moved config location out of Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ FROM python:3-slim
 COPY --from=builder /root/.local /root/.local
 ENV PATH=/root/.local/bin:$PATH
 EXPOSE 8025
-CMD [ "mailrise", "/etc/mailrise.conf" ]
+ENTRYPOINT [ "mailrise" ]

--- a/src/mailrise/config.py
+++ b/src/mailrise/config.py
@@ -105,7 +105,7 @@ class MailriseConfig:
     senders: dict[str, Sender]
 
 
-def load_config(logger: Logger, f: io.TextIOWrapper) -> MailriseConfig:
+def load_config(logger: Logger, f: str) -> MailriseConfig:
     """Loads configuration data from a YAML file.
 
     Args:
@@ -118,7 +118,8 @@ def load_config(logger: Logger, f: io.TextIOWrapper) -> MailriseConfig:
     Raises:
         ConfigFileError: The configuration file is invalid.
     """
-    yml = yaml.safe_load(f)
+    with open(f, 'r') as file:
+        yml = yaml.safe_load(file)
     if not isinstance(yml, dict):
         raise ConfigFileError("root node not a mapping")
 

--- a/src/mailrise/skeleton.py
+++ b/src/mailrise/skeleton.py
@@ -39,6 +39,7 @@ _logger = logging.getLogger(__name__)
 
 
 def parse_args(args: list[str]) -> argparse.Namespace:
+    import os
     """Parse command line parameters.
 
     Args:
@@ -56,10 +57,12 @@ def parse_args(args: list[str]) -> argparse.Namespace:
         version="mailrise {ver}".format(ver=__version__),
     )
     parser.add_argument(
+        "-c",
+        "--config",
         dest="config",
+        default=os.environ.get("CONFIG", "/etc/mailrise.yaml"),
         help="path to configuration file",
-        type=argparse.FileType("r"),
-        metavar="CONFIG"
+        metavar="CONFIG",
     )
     parser.add_argument(
         "-v",


### PR DESCRIPTION
My goal is to use this library. However, the Dockerfile requiring the config being in a known location before the container is running prevented it from launching. I've made the config optional while retaining a default option and moving the file loading into the config.