### PR TITLE
Changed Dockerfile from CMD to ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,4 +9,4 @@ FROM python:3-slim
 COPY --from=builder /root/.local /root/.local
 ENV PATH=/root/.local/bin:$PATH
 EXPOSE 8025
-CMD [ "mailrise", "/etc/mailrise.conf" ]
+ENTRYPOINT [ "mailrise" ]


### PR DESCRIPTION
Much smaller change fixed the problem.

I'm using the Docker container to run in Kubernetes. The volume only gets mounted when the container is launching. By requiring the config path argument to be available in the `CMD` of the Dockerfile was preventing Kubernetes from finding the path. Using `ENTRYPOINT` in the Dockerfile allows the user to pass the path in the commandline as `docker run -it --rm -v ./config/mailrise.yaml:/etc/mailrise.yaml mailrise:latest /etc/mailrise.yaml` (notice the final positional argument). This didn't require any code changes and provides Docker users more flexibility.