### PR TITLE
feature: add HTML to text conversion option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ __pycache__/*
 .*.swp
 */.ipynb_checkpoints/*
 .DS_Store
+mailrise.yaml
 
 # Project files
 .ropeproject
@@ -49,5 +50,6 @@ cover/*
 MANIFEST
 
 # Per-project virtualenvs
+venv/
 .venv*/
 .conda*/

--- a/README.rst
+++ b/README.rst
@@ -106,58 +106,60 @@ encapsulates the daemon's entire configuration. The root node of this file shoul
 be a dictionary. Mailrise accepts the following keys (periods denote
 sub-dictionaries):
 
-====================================== ========== ==========================================================================
-Key                                    Type       Value
-====================================== ========== ==========================================================================
-configs.<name>                         dictionary ``<name>`` denotes the name of the configuration. It must *not* contain a
-                                                  period. Senders select this configuration by addressing their emails to
-                                                  ``<name>@mailrise.xyz``.
+=============================================== ========== ==========================================================================
+Key                                             Type       Value
+=============================================== ========== ==========================================================================
+configs.<name>                                  dictionary ``<name>`` denotes the name of the configuration. It must *not* contain a
+                                                           period. Senders select this configuration by addressing their emails to
+                                                           ``<name>@mailrise.xyz``.
 
-                                                  It is also possible to use a full email address, such as
-                                                  ``mail@example.com``, as a name, in which case senders must use the entire
-                                                  address as their recipient address to select this configuration.
+                                                           It is also possible to use a full email address, such as
+                                                           ``mail@example.com``, as a name, in which case senders must use the entire
+                                                           address as their recipient address to select this configuration.
 
-                                                  The dictionary value is the Apprise
-                                                  `YAML configuration <https://github.com/caronc/apprise/wiki/config_yaml>`_
-                                                  itself, exactly as it would be specified in a standalone file for Apprise.
+                                                           The dictionary value is the Apprise
+                                                           `YAML configuration <https://github.com/caronc/apprise/wiki/config_yaml>`_
+                                                           itself, exactly as it would be specified in a standalone file for Apprise.
 
-                                                  In addition to the Apprise configuration, some Mailrise-exclusive options
-                                                  can be specified under this key. See the ``mailrise`` options below.
-configs.<name>.mailrise.title_template string     The template string used to create notification titles. See "Template
-                                                  strings" below.
+                                                           In addition to the Apprise configuration, some Mailrise-exclusive options
+                                                           can be specified under this key. See the ``mailrise`` options below.
+configs.<name>.mailrise.title_template          string     The template string used to create notification titles. See "Template
+                                                           strings" below.
 
-                                                  Defaults to ``$subject ($from)``.
-configs.<name>.mailrise.body_template  string     The template string used to create notification body texts. See "Template
-                                                  strings" below.
+                                                           Defaults to ``$subject ($from)``.
+configs.<name>.mailrise.body_template           string     The template string used to create notification body texts. See "Template
+                                                           strings" below.
 
-                                                  Defaults to ``$body``.
-configs.<name>.mailrise.body_format    string     Sets the data type for notification body texts. Must be ``text``,
-                                                  ``html``, or ``markdown``. Apprise
-                                                  `uses <https://github.com/caronc/apprise/wiki/Development_API#notify--send-notifications>`_
-                                                  this information to determine whether or not the upstream notification
-                                                  service can handle the provided content.
+                                                           Defaults to ``$body``.
+configs.<name>.mailrise.body_format             string     Sets the data type for notification body texts. Must be ``text``,
+                                                           ``html``, or ``markdown``. Apprise
+                                                           `uses <https://github.com/caronc/apprise/wiki/Development_API#notify--send-notifications>`_
+                                                           this information to determine whether or not the upstream notification
+                                                           service can handle the provided content.
+                                                           
+                                                           If not specified here, the data type is inferred from the body part of the
+                                                           email message. So if you have your body template set to anything but the
+                                                           default value of ``$body``, you might want to set a data type here.
+configs.<name>.mailrise.html_conversion         string     The HTML conversion string is used to convert HTML messages to text format. The original 
+                                                           formatting is kept the best it can be when converting.
 
-                                                  If not specified here, the data type is inferred from the body part of the
-                                                  email message. So if you have your body template set to anything but the
-                                                  default value of ``$body``, you might want to set a data type here.
-listen.host                            string     Specifies the network address to listen on.
+                                                           Defaults to ``None``.
+listen.host                                     string     Specifies the network address to listen on.
 
-                                                  Defaults to all interfaces.
-listen.port                            number     Specifies the network port to listen on.
+                                                           Defaults to all interfaces.
+listen.port                                     number     Specifies the network port to listen on.
 
-                                                  Defaults to 8025.
-tls.mode                               string     Selects the operating mode for TLS encryption. Must be ``off``,
-                                                  ``onconnect``, ``starttls``, or ``starttlsrequire``.
+                                                           Defaults to 5000.
+tls.mode                                        string     Selects the operating mode for TLS encryption. Must be ``off``,
+                                                           ``onconnect``, ``starttls``, or ``starttlsrequire``.
 
-                                                  Defaults to off.
-tls.certfile                           string     If TLS is enabled, specifies the path to the certificate chain file. This
-                                                  file must be unencrypted and in PEM format.
-tls.keyfile                            string     If TLS is enabled, specifies the path to the key file. This file must be
-                                                  unencrypted and in PEM format.
-smtp.hostname                          string     Specifies the hostname used when responding to the EHLO command.
-
-                                                  Defaults to the system FQDN.
-====================================== ========== ==========================================================================
+                                                           Defaults to off.
+tls.certfile                                    string     If TLS is enabled, specifies the path to the certificate chain file. This
+                                                           file must be unencrypted and in PEM format.
+tls.keyfile                                     string     If TLS is enabled, specifies the path to the key file. This file must be
+                                                           unencrypted and in PEM format.
+smtp.hostname                                   string     Specifies the hostname used when responding to the EHLO command.
+=============================================== ========== ==========================================================================
 
 .. _template-strings:
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -134,6 +134,6 @@ exclude =
 [pyscaffold]
 # PyScaffold's parameters when the project was created.
 # This will be used when updating. Do not change!
-version = 4.0.2
+version = 4.0.3
 package = mailrise
 extensions = 

--- a/src/mailrise/config.py
+++ b/src/mailrise/config.py
@@ -93,11 +93,13 @@ class Sender(NamedTuple):
         body_template: The template string for notification body texts.
         body_format: The content type for notifications. If None, this will be
             auto-detected from the body parts of emails.
+        html_conversion: The option to convert html to a different format.
     """
     apprise: apprise.Apprise
     title_template: Template
     body_template: Template
     body_format: typ.Optional[apprise.NotifyFormat]
+    html_conversion: typ.Optional[str]
 
 
 class MailriseConfig(NamedTuple):
@@ -200,11 +202,15 @@ def _load_sender(config: dict[str, typ.Any]) -> Sender:
     title_template = mr_config.get('title_template', '$subject ($from)')
     body_template = mr_config.get('body_template', '$body')
     body_format = mr_config.get('body_format', None)
+    html_conversion = mr_config.get('html_conversion', None)
     if not any(body_format == c for c in (None,
                                           apprise.NotifyFormat.TEXT,
                                           apprise.NotifyFormat.HTML,
                                           apprise.NotifyFormat.MARKDOWN)):
         raise ConfigFileError(f"invalid apprise notification format: {body_format}")
+    if not any(html_conversion == c for c in (None,
+                                              'text')):
+        raise ConfigFileError(f"invalid mailrise html conversion option: {html_conversion}")
 
     aconfig = apprise.AppriseConfig(asset=DEFAULT_ASSET)
     aconfig.add_config(yaml.safe_dump(config), format='yaml')
@@ -214,5 +220,6 @@ def _load_sender(config: dict[str, typ.Any]) -> Sender:
         apprise=apobj,
         title_template=Template(title_template),
         body_template=Template(body_template),
-        body_format=body_format
+        body_format=body_format,
+        html_conversion=html_conversion,
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -82,6 +82,7 @@ def test_mailrise_options() -> None:
             mailrise:
               title_template: ""
               body_format: "text"
+              html_conversion: "text"
     """)
     mrise = load_config(_logger, f)
     assert len(mrise.senders) == 1
@@ -91,7 +92,8 @@ def test_mailrise_options() -> None:
     sender = mrise.senders[key]
     assert sender.title_template.template == ''
     assert sender.body_format == NotifyFormat.TEXT
-
+    assert sender.html_conversion == NotifyFormat.TEXT
+    
     with pytest.raises(ConfigFileError):
         f = StringIO("""
             configs:


### PR DESCRIPTION
Added the HTML to text conversion option directly to Mailrise. Updated the "test_config".py to support testing. Updated the README.rst to show where the HTML to text conversion option can be enabled.