### PR TITLE
Update apprise to v1.2.0

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -54,7 +54,7 @@ python_requires = >=3.8
 # For more information, check out https://semver.org/.
 install_requires =
     importlib-metadata; python_version<"3.8"
-    apprise>=0.9.5
+    apprise>=1.2.0
     aiosmtpd
     pyyaml
 


### PR DESCRIPTION
I ran into https://github.com/caronc/apprise/issues/717 while trying to use mailrise to send notifications to Discord.  It was fixed in apprise v1.2.0.  This PR just updates setup.cfg to require the latest released version of apprise.

I assume you could just kick off the docker build again and it would basically achieve the same result, so whatever works for you.