### PR TITLE
Update README.rst - Fix Telegram URL in sample

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -259,7 +259,7 @@ underlying JSON structure, a useful aid.
       #
       telegram_and_discord:
         urls:
-          - tgam://MY_BOT_TOKEN
+          - tgram://MY_BOT_TOKEN
           - discord://WEBHOOK_ID/WEBHOOK_TOKEN
         # You can also control the layout of the message with custom template
         # strings.


### PR DESCRIPTION
In `README.rst` the Telegram URL is incorrect. Caused me a few minutes of confusion when setting up Mailrise for the first time (love it by the way!)

Old/incorrect:
`- tgam://MY_BOT_TOKEN`

New/correct:
`- tgram://MY_BOT_TOKEN`