### PR TITLE
Fix Windows compatibility

### DIFF
--- a/src/mailrise/skeleton.py
+++ b/src/mailrise/skeleton.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 import signal
 import ssl
 import sys
@@ -147,8 +148,15 @@ def main(args: list[str]) -> None:
         _logger.info('Caught exit signal...')
         eloop.stop()
         controller.end()
+
+    def clean_exit_nt(signal, frame):
+        clean_exit()
+
     for sig in (signal.SIGINT, signal.SIGTERM):
-        eloop.add_signal_handler(sig, clean_exit)
+        if os.name == 'nt':
+            signal.signal(sig, clean_exit_nt)
+        else:
+            eloop.add_signal_handler(sig, clean_exit)
 
     controller.begin()
     eloop.run_forever()


### PR DESCRIPTION
If you try to run mailrise on Windows, you will get this error:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "C:\Users\Brian\AppData\Roaming\Python\Python311\Scripts\mailrise.exe\__main__.py", line 7, in <module>
  File "C:\Users\Brian\AppData\Roaming\Python\Python311\site-packages\mailrise\skeleton.py", line 170, in run
    main(sys.argv[1:])
  File "C:\Users\Brian\AppData\Roaming\Python\Python311\site-packages\mailrise\skeleton.py", line 159, in main
    eloop.add_signal_handler(sig, clean_exit)
  File "C:\Python311\Lib\asyncio\events.py", line 574, in add_signal_handler
    raise NotImplementedError
NotImplementedError
```

The root cause of this issue is `loop.add_signal_handler` is not available on Windows according to the [Python Event Loop documentation](https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.add_signal_handler)

Therefore, I changed it to call `signal.signal` on Windows. It may not be the best solution, but at least it can now run on Windows.