### PR TITLE
Fix TypeError: unsupported operand type(s) for |: '_LiteralGenericAlias' and 'NoneType'

### DIFF
--- a/src/mailrise/router.py
+++ b/src/mailrise/router.py
@@ -92,8 +92,8 @@ class AppriseNotification(typ.NamedTuple):
     notify_type: NotifyType = NotifyType.INFO
     body_format: NotifyFormat = NotifyFormat.TEXT
     attachments: typ.List[EmailAttachment] = []
-    config_format: typ.Literal['text', 'yaml'] | None = None
-    asset: AppriseAsset | None = None
+    config_format: typ.Union[typ.Literal['text', 'yaml'], None] = None
+    asset: typ.Union[AppriseAsset, None] = None
 
 
 class Router(metaclass=ABCMeta):  # pylint: disable=too-few-public-methods

--- a/src/mailrise/simple_router.py
+++ b/src/mailrise/simple_router.py
@@ -141,7 +141,7 @@ class SimpleRouter(Router):  # pylint: disable=too-few-public-methods
                 attachments=email.attachments
             )
 
-    def get_sender(self, key: _Key) -> _SimpleSender | None:
+    def get_sender(self, key: _Key) -> typ.Union[_SimpleSender, None]:
         """Find a sender by recipient key."""
         return next(
             (sender for (pattern_key, sender) in self.senders


### PR DESCRIPTION
Hi,

Running this from a fresh pip install throws out the error on python 3.9.2:

TypeError: unsupported operand type(s) for |: '_LiteralGenericAlias' and 'NoneType'

Using typing.Union instead of | seems to fix the problem. Haven't found more ocurrences of this, but I haven't looked to deep for them, so feel free to add to this.

Regards!