### PR TITLE
Prefer plain text body when available

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,3 +4,4 @@ Contributors
 
 * Ryan Young <ryan@youngryan.com>
 * Emily Young <em.therese.young@gmail.com>
+* Matthew Foran <matthewjforan@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -210,6 +210,9 @@ listen.host                            string     Specifies the network address 
 listen.port                            number     Specifies the network port to listen on.
 
                                                   Defaults to 8025.
+prefer_plain                           bool       Prefer the plain text email type over html (when available).
+
+                                                  Defaults to True.
 tls.mode                               string     Selects the operating mode for TLS encryption. Must be ``off``,
                                                   ``onconnect``, ``starttls``, or ``starttlsrequire``.
 

--- a/src/mailrise/config.py
+++ b/src/mailrise/config.py
@@ -118,7 +118,7 @@ def load_config(logger: Logger, file: io.TextIOWrapper) -> MailriseConfig:
 
     yml_listen = yml.get('listen', {})
 
-    prefer_plain = yml.get('prefer_plain', False)
+    prefer_plain = yml.get('prefer_plain', True)
 
     yml_tls = yml.get('tls', {})
     # "off" is a boolean value in YAML, so it will get parsed as False.

--- a/src/mailrise/config.py
+++ b/src/mailrise/config.py
@@ -66,6 +66,7 @@ class MailriseConfig(NamedTuple):
         logger: The logger, which is used to record interesting events.
         listen_host: The network address to listen on.
         listen_port: The network port to listen on.
+        prefer_plain: prefer text/plain over text/html email.
         tls_mode: The TLS encryption mode.
         tls_certfile: The path to the TLS certificate chain file.
         tls_keyfile: The path to the TLS key file.
@@ -77,6 +78,7 @@ class MailriseConfig(NamedTuple):
     logger: Logger
     listen_host: str
     listen_port: int
+    prefer_plain: bool
     tls_mode: TLSMode
     tls_certfile: typ.Optional[str]
     tls_keyfile: typ.Optional[str]
@@ -116,6 +118,8 @@ def load_config(logger: Logger, file: io.TextIOWrapper) -> MailriseConfig:
 
     yml_listen = yml.get('listen', {})
 
+    prefer_plain = yml.get('prefer_plain', False)
+
     yml_tls = yml.get('tls', {})
     # "off" is a boolean value in YAML, so it will get parsed as False.
     yml_tls_mode = (yml_tls.get('mode', False) or "off").upper()
@@ -153,6 +157,7 @@ def load_config(logger: Logger, file: io.TextIOWrapper) -> MailriseConfig:
         logger=logger,
         listen_host=yml_listen.get('host', ''),
         listen_port=yml_listen.get('port', 8025),
+        prefer_plain=prefer_plain,
         tls_mode=tls_mode,
         tls_certfile=tls_certfile,
         tls_keyfile=tls_keyfile,

--- a/src/mailrise/smtp.py
+++ b/src/mailrise/smtp.py
@@ -76,7 +76,7 @@ class AppriseHandler(typ.NamedTuple):
         message = parser.parsebytes(envelope.content)
         assert isinstance(message, StdlibEmailMessage)
         try:
-            notification = _parsemessage(message, envelope)
+            notification = _parsemessage(message, envelope, self.config.prefer_plain)
         except UnreadableMultipart as mpe:
             subparts = \
                 ' '.join(part.get_content_type() for part in mpe.message.iter_parts())
@@ -104,7 +104,7 @@ class AppriseHandler(typ.NamedTuple):
         return '250 OK'
 
 
-def _parsemessage(msg: StdlibEmailMessage, envelope: Envelope) -> r.EmailMessage:
+def _parsemessage(msg: StdlibEmailMessage, envelope: Envelope, prefer_plain: bool) -> r.EmailMessage:
     """Parses an email message into an `EmailNotification`.
 
     Args:
@@ -113,18 +113,14 @@ def _parsemessage(msg: StdlibEmailMessage, envelope: Envelope) -> r.EmailMessage
     Returns:
         The `EmailNotification` instance.
     """
-    py_body_part = msg.get_body()
+    if prefer_plain:
+        py_body_part = msg.get_body(preferencelist=('plain', 'html'))
+    else:
+        py_body_part = msg.get_body(preferencelist=('html', 'plain'))
     body: typ.Optional[tuple[str, apprise.NotifyFormat]]
     if isinstance(py_body_part, StdlibEmailMessage):
-        body_part: StdlibEmailMessage
-        try:
-            py_body_part.get_content()
-        except KeyError:  # stdlib failed to read the content, which means multipart
-            body_part = _getmultiparttext(py_body_part)
-        else:
-            body_part = py_body_part
-        body_content = contentmanager.raw_data_manager.get_content(body_part)
-        is_html = body_part.get_content_subtype() == 'html'
+        body_content = contentmanager.raw_data_manager.get_content(py_body_part)
+        is_html = py_body_part.get_content_subtype() == 'html'
         body = (body_content.strip(),
                 apprise.NotifyFormat.HTML if is_html else apprise.NotifyFormat.TEXT)
     else:
@@ -141,23 +137,6 @@ def _parsemessage(msg: StdlibEmailMessage, envelope: Envelope) -> r.EmailMessage
         body_format=body[1] if body else apprise.NotifyFormat.TEXT,
         attachments=attachments
     )
-
-
-def _getmultiparttext(msg: StdlibEmailMessage) -> StdlibEmailMessage:
-    """Search for the textual body part of a multipart email."""
-    content_type = msg.get_content_type()
-    if content_type in ('multipart/related', 'multipart/alternative'):
-        parts = list(msg.iter_parts())
-        # Look for these types of parts in descending order.
-        for parttype in ('multipart/alternative', 'multipart/related',
-                         'text/html', 'text/plain'):
-            found = \
-                next((p for p in parts if isinstance(p, StdlibEmailMessage)
-                     and p.get_content_type() == parttype), None)
-            if found is not None:
-                return _getmultiparttext(found)
-        raise UnreadableMultipart(msg)
-    return msg
 
 
 def _parseattachment(part: StdlibEmailMessage) -> r.EmailAttachment:


### PR DESCRIPTION
**Problem:** #135

**Solution:** While familiarizing with the python email library, I noticed that [`get_body()`](https://docs.python.org/3/library/email.message.html#email.message.EmailMessage.get_body) accepts a parameter for which MIME type you want to receive. I found that adding this parameter and removing the current multipart parser works for my use case. I also added a config option to switch between text/html-preferred.

**Testing**: I only tested on my personal use case. I'm not sure why `_getmultiparttext` exists in the first place; maybe there are some cases where `get_body()` fails? Maybe when this was first implemented `get_body()` did not parse multipart messages?

I wasn't sure if the config option should be global or per-address.